### PR TITLE
BUG: Fix disconnect errors

### DIFF
--- a/VolumeReconstruction/qSlicerVolumeReconstructionModule.cxx
+++ b/VolumeReconstruction/qSlicerVolumeReconstructionModule.cxx
@@ -87,7 +87,7 @@ qSlicerVolumeReconstructionModule::qSlicerVolumeReconstructionModule(QObject* _p
 qSlicerVolumeReconstructionModule::~qSlicerVolumeReconstructionModule()
 {
   Q_D(qSlicerVolumeReconstructionModule);
-  disconnect(&d->LiveVolumeReconstructionTimer, SIGNAL(timeout(QString)), this, SLOT(updateLiveVolumeReconstruction()));
+  disconnect(&d->LiveVolumeReconstructionTimer, SIGNAL(timeout()), this, SLOT(updateLiveVolumeReconstruction()));
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes the following errors that happen when closing Slicer

```
QObject::disconnect: No such signal QTimer::timeout(QString)
QObject::disconnect:  (receiver name: 'VolumeReconstructionModule')
```

cc: @Sunderlandkyl 