### PR TITLE
BUG: Sequence Metafile reader truncates data when scalar type is long…

### DIFF
--- a/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.cxx
+++ b/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.cxx
@@ -182,7 +182,7 @@ vtkMRMLSequenceNode* vtkSlicerMetafileImporterLogic::ReadSequenceMetafileImages(
   emptySliceImageData->SetSpacing(spacing[0],spacing[1],1);
   emptySliceImageData->SetOrigin(0,0,0);
 
-  int sliceSize=imageData->GetIncrements()[2];
+  int sliceSize=imageData->GetIncrements()[2] * imageData->GetScalarSize();
   for ( int frameNumber = 0; frameNumber < dimensions[2]; frameNumber++ )
   {
     // Add the image slice to scene as a volume


### PR DESCRIPTION
…er than bytes

The `ReadSequenceMetafileImages` function deep copies image data per slice via `memcpy`, but `memcpy` assumes the size given is in bytes. The current functionality doesn't copy all the data if the scalar type is something larger than bytes.

cc @jamesobutler for review