### PR TITLE
ENH: Use name property in meta file sequence reader

### DIFF
--- a/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.h
+++ b/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.h
@@ -24,6 +24,9 @@
 #ifndef __vtkSlicerMetafileImporterLogic_h
 #define __vtkSlicerMetafileImporterLogic_h
 
+// SlicerQt includes
+#include "qSlicerFileReader.h"
+
 // MRML Sequence includes
 #include "vtkMRMLLinearTransformSequenceStorageNode.h"
 
@@ -81,7 +84,8 @@ public:
     \param addedNodes if not NULL then returns sequence nodes that are added to the scene.
     Returns the created browser node on success, NULL on failure.
   */
-  vtkMRMLSequenceBrowserNode* ReadSequenceFile(const std::string& fileName, vtkCollection* addedSequenceNodes=NULL);
+  vtkMRMLSequenceBrowserNode* ReadSequenceFile(const std::string& fileName, vtkCollection* addedSequenceNodes=NULL,
+      const qSlicerFileReader::IOProperties& properties=qSlicerFileReader::IOProperties());
 
   /*! Write sequence metafile contents to the file */
   bool WriteSequenceMetafile(const std::string& fileName, vtkMRMLSequenceBrowserNode* browserNode);

--- a/MetafileImporter/qSlicerMetafileReader.cxx
+++ b/MetafileImporter/qSlicerMetafileReader.cxx
@@ -106,7 +106,7 @@ bool qSlicerMetafileReader::load(const IOProperties& properties)
 
   vtkNew<vtkCollection> loadedSequenceNodes;
 
-  vtkMRMLSequenceBrowserNode* browserNode = d->MetafileImporterLogic->ReadSequenceFile(fileName.toStdString(), loadedSequenceNodes.GetPointer());
+  vtkMRMLSequenceBrowserNode* browserNode = d->MetafileImporterLogic->ReadSequenceFile(fileName.toStdString(), loadedSequenceNodes.GetPointer(), properties);
   if (browserNode == NULL)
   {
     return false;


### PR DESCRIPTION
I have a program where users can load .seq.mha's one at a time. My program reads meta info in those mha's and groups the sequence images accordingly into one sequence browser. Unfortunately every time a new sequence file is loaded, a new browser is created, so I end up having to write a lot of code to delete the browser, then add the sequence nodes to the compilation browser, then delete the proxy nodes that are automatically created when `AddSynchronizedSequenceNode` is called.

I've noticed that when loading .seq.nrrd's the "name" property is used in that reader.
![image](https://user-images.githubusercontent.com/40271210/148302841-c9568c08-e847-4768-b747-09d39d2dcdb8.png)

This PR adds the ability to import a sequence metafile with the name property set. The browser, image proxy, and image sequence nodes will use this name. If a browser exists with that name the new sequences will be added to it.
![image](https://user-images.githubusercontent.com/40271210/148303080-f4a78a58-4202-409d-9fa1-0acf8805c1f9.png)

I'm also open to instead having a property like "browserID" to explicitly define the browser?