### PR TITLE
ENH: Add outputBrowserNodeID property to meta seq reader

### DIFF
--- a/MetafileImporter/CMakeLists.txt
+++ b/MetafileImporter/CMakeLists.txt
@@ -20,6 +20,8 @@ set(MODULE_INCLUDE_DIRECTORIES
   )
 
 set(MODULE_SRCS
+  qSlicerMetafileIOOptionsWidget.cxx
+  qSlicerMetafileIOOptionsWidget.h
   qSlicer${MODULE_NAME}Module.cxx
   qSlicer${MODULE_NAME}Module.h
   qSlicer${MODULE_NAME}ModuleWidget.cxx
@@ -29,12 +31,14 @@ set(MODULE_SRCS
   )
 
 set(MODULE_MOC_SRCS
+  qSlicerMetafileIOOptionsWidget.h
   qSlicer${MODULE_NAME}Module.h
   qSlicer${MODULE_NAME}ModuleWidget.h
   qSlicerMetafileReader.h
   )
 
 set(MODULE_UI_SRCS
+  Resources/UI/qSlicerMetafileIOOptionsWidget.ui
   Resources/UI/qSlicer${MODULE_NAME}ModuleWidget.ui
   )
 

--- a/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.cxx
+++ b/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.cxx
@@ -173,7 +173,7 @@ vtkMRMLSequenceNode* vtkSlicerMetafileImporterLogic::ReadSequenceMetafileImages(
   {
     imagesSequenceNode = vtkSmartPointer<vtkMRMLSequenceNode>::New();
   }
-  
+
   this->GetMRMLScene()->AddNode(imagesSequenceNode);
   imagesSequenceNode->SetIndexName("time");
   imagesSequenceNode->SetIndexUnit("s");
@@ -302,7 +302,8 @@ void vtkSlicerMetafileImporterLogic::WriteSequenceMetafileImages(const std::stri
 }
 
 //----------------------------------------------------------------------------
-vtkMRMLSequenceBrowserNode* vtkSlicerMetafileImporterLogic::ReadSequenceFile(const std::string& fileName, vtkCollection* addedSequenceNodes/*=NULL*/)
+vtkMRMLSequenceBrowserNode* vtkSlicerMetafileImporterLogic::ReadSequenceFile(const std::string& fileName, vtkCollection* addedSequenceNodes/*=NULL*/,
+const std::string& outputBrowserNodeID/*=std::string()*/)
 {
   // Map the frame numbers to timestamps
   std::map< int, std::string > frameNumberToIndexValueMap;
@@ -393,11 +394,18 @@ vtkMRMLSequenceBrowserNode* vtkSlicerMetafileImporterLogic::ReadSequenceFile(con
       // push to front as we prefer the image to be the master node
       createdSequenceNodes.push_front(createdImageNode);
     }
-    vtkSmartPointer<vtkCollection> foundSequenceBrowserNodes = vtkSmartPointer<vtkCollection>::Take(
-      this->GetMRMLScene()->GetNodesByClassByName("vtkMRMLSequenceBrowserNode", shortestBaseNodeName.c_str()));
-    if (foundSequenceBrowserNodes->GetNumberOfItems() > 0)
+    if (!outputBrowserNodeID.empty())
     {
-      sequenceBrowserNode = vtkMRMLSequenceBrowserNode::SafeDownCast(foundSequenceBrowserNodes->GetItemAsObject(0));
+        sequenceBrowserNode = vtkMRMLSequenceBrowserNode::SafeDownCast(this->GetMRMLScene()->GetNodeByID(outputBrowserNodeID));
+    }
+    else
+    {
+      vtkSmartPointer<vtkCollection> foundSequenceBrowserNodes = vtkSmartPointer<vtkCollection>::Take(
+        this->GetMRMLScene()->GetNodesByClassByName("vtkMRMLSequenceBrowserNode", shortestBaseNodeName.c_str()));
+      if (foundSequenceBrowserNodes->GetNumberOfItems() > 0)
+      {
+        sequenceBrowserNode = vtkMRMLSequenceBrowserNode::SafeDownCast(foundSequenceBrowserNodes->GetItemAsObject(0));
+      }
     }
     if (!sequenceBrowserNode)
     {

--- a/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.h
+++ b/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.h
@@ -81,7 +81,7 @@ public:
     \param addedNodes if not NULL then returns sequence nodes that are added to the scene.
     Returns the created browser node on success, NULL on failure.
   */
-  vtkMRMLSequenceBrowserNode* ReadSequenceFile(const std::string& fileName, vtkCollection* addedSequenceNodes=NULL);
+  vtkMRMLSequenceBrowserNode* ReadSequenceFile(const std::string& fileName, vtkCollection* addedSequenceNodes=NULL, const std::string& outputBrowserID=std::string());
 
   /*! Write sequence metafile contents to the file */
   bool WriteSequenceMetafile(const std::string& fileName, vtkMRMLSequenceBrowserNode* browserNode);

--- a/MetafileImporter/Resources/UI/qSlicerMetafileIOOptionsWidget.ui
+++ b/MetafileImporter/Resources/UI/qSlicerMetafileIOOptionsWidget.ui
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>qSlicerMetafileIOOptionsWidget</class>
+ <widget class="qSlicerWidget" name="qSlicerMetafileIOOptionsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>552</width>
+    <height>27</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Volume Options</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="OutputBrowserNodeIDLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Output Browser Node ID</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="OutputBrowserNodeIDEdit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qSlicerWidget</class>
+   <extends>QWidget</extends>
+   <header>qSlicerWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/MetafileImporter/qSlicerMetafileIOOptionsWidget.cxx
+++ b/MetafileImporter/qSlicerMetafileIOOptionsWidget.cxx
@@ -1,0 +1,70 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Julien Finet, Kitware Inc.
+  and was partially funded by NIH grant 3P41RR013218-12S1
+
+==============================================================================*/
+
+// CTK includes
+#include <ctkFlowLayout.h>
+#include <ctkUtils.h>
+
+// VTK includes
+#include <vtkNew.h>
+
+/// Volumes includes
+#include "qSlicerIOOptions_p.h"
+#include "qSlicerMetafileIOOptionsWidget.h"
+#include "ui_qSlicerMetafileIOOptionsWidget.h"
+
+//-----------------------------------------------------------------------------
+/// \ingroup Slicer_QtModules_Metafiles
+class qSlicerMetafileIOOptionsWidgetPrivate
+  : public qSlicerIOOptionsPrivate
+  , public Ui_qSlicerMetafileIOOptionsWidget
+{
+public:
+};
+
+//-----------------------------------------------------------------------------
+qSlicerMetafileIOOptionsWidget::qSlicerMetafileIOOptionsWidget(QWidget* parentWidget)
+  : qSlicerIOOptionsWidget(new qSlicerMetafileIOOptionsWidgetPrivate, parentWidget)
+{
+  Q_D(qSlicerMetafileIOOptionsWidget);
+  d->setupUi(this);
+
+  ctkFlowLayout::replaceLayout(this);
+
+  connect(d->OutputBrowserNodeIDEdit, SIGNAL(textChanged(QString)),
+          this, SLOT(updateProperties()));
+}
+
+//-----------------------------------------------------------------------------
+qSlicerMetafileIOOptionsWidget::~qSlicerMetafileIOOptionsWidget() = default;
+
+//-----------------------------------------------------------------------------
+void qSlicerMetafileIOOptionsWidget::updateProperties()
+{
+  Q_D(qSlicerMetafileIOOptionsWidget);
+  if (!d->OutputBrowserNodeIDEdit->text().isEmpty())
+    {
+    d->Properties["outputBrowserNodeID"] = d->OutputBrowserNodeIDEdit->text();
+    }
+  else
+    {
+    d->Properties.remove("outputBrowserNodeID");
+    }
+}

--- a/MetafileImporter/qSlicerMetafileIOOptionsWidget.h
+++ b/MetafileImporter/qSlicerMetafileIOOptionsWidget.h
@@ -1,0 +1,49 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Julien Finet, Kitware Inc.
+  and was partially funded by NIH grant 3P41RR013218-12S1
+
+==============================================================================*/
+
+#ifndef __qSlicerMetafileIOOptionsWidget_h
+#define __qSlicerMetafileIOOptionsWidget_h
+
+// CTK includes
+#include <ctkPimpl.h>
+
+// Slicer includes
+#include "qSlicerIOOptionsWidget.h"
+
+class qSlicerMetafileIOOptionsWidgetPrivate;
+
+/// \ingroup Slicer_QtModules_MetafileImporter
+class qSlicerMetafileIOOptionsWidget :
+	public qSlicerIOOptionsWidget
+{
+	Q_OBJECT
+public:
+	qSlicerMetafileIOOptionsWidget(QWidget* parent = nullptr);
+	~qSlicerMetafileIOOptionsWidget() override;
+
+protected slots:
+	void updateProperties();
+
+private:
+	Q_DECLARE_PRIVATE_D(qGetPtrHelper(qSlicerIOOptions::d_ptr), qSlicerMetafileIOOptionsWidget);
+	Q_DISABLE_COPY(qSlicerMetafileIOOptionsWidget);
+};
+
+#endif

--- a/MetafileImporter/qSlicerMetafileReader.cxx
+++ b/MetafileImporter/qSlicerMetafileReader.cxx
@@ -106,7 +106,12 @@ bool qSlicerMetafileReader::load(const IOProperties& properties)
 
   vtkNew<vtkCollection> loadedSequenceNodes;
 
-  vtkMRMLSequenceBrowserNode* browserNode = d->MetafileImporterLogic->ReadSequenceFile(fileName.toStdString(), loadedSequenceNodes.GetPointer());
+  QString outputBrowserNodeID;
+  if (properties.contains("outputBrowserNodeID"))
+  {
+      outputBrowserNodeID = properties["outputBrowserNodeID"].toString();
+  }
+  vtkMRMLSequenceBrowserNode* browserNode = d->MetafileImporterLogic->ReadSequenceFile(fileName.toStdString(), loadedSequenceNodes.GetPointer(), outputBrowserNodeID.toStdString());
   if (browserNode == NULL)
   {
     return false;

--- a/MetafileImporter/qSlicerMetafileReader.cxx
+++ b/MetafileImporter/qSlicerMetafileReader.cxx
@@ -25,6 +25,7 @@
 // SlicerQt includes
 #include "qSlicerApplication.h"
 #include "qSlicerMetafileReader.h"
+#include "qSlicerMetafileIOOptionsWidget.h"
 #include "qSlicerMetafileImporterModule.h"
 #include "qSlicerSequencesModule.h"
 #include "qSlicerAbstractModuleRepresentation.h"
@@ -92,6 +93,15 @@ qSlicerIO::IOFileType qSlicerMetafileReader::fileType() const
 QStringList qSlicerMetafileReader::extensions() const
 {
   return QStringList() << "Sequence Metafile (*.seq.mha *.seq.mhd *.mha *.mhd)";
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIOOptions* qSlicerMetafileReader::options() const
+{
+  // set the mrml scene on the options widget to allow selecting a color node
+  qSlicerIOOptionsWidget* options = new qSlicerMetafileIOOptionsWidget;
+  options->setMRMLScene(this->mrmlScene());
+  return options;
 }
 
 //-----------------------------------------------------------------------------

--- a/MetafileImporter/qSlicerMetafileReader.h
+++ b/MetafileImporter/qSlicerMetafileReader.h
@@ -44,6 +44,7 @@ public:
   virtual QString description() const;
   virtual IOFileType fileType() const;
   virtual QStringList extensions() const;
+  qSlicerIOOptions* options()const override;
 
   virtual bool load( const IOProperties& properties );
   


### PR DESCRIPTION
This adds a new loading property to the meta file sequence reader, "outputBrowserNodeID". This is convenient for if you already have a browser in the scene you want to add the new sequences to.

To test the PR, in the python console you can execute:
`slicer.util.loadNodeFromFile(sequence_filepath, "Sequence Metafile", properties={"outputBrowserNodeID":"browser_id"})`