### PR TITLE
ENH: Add saveSequenceChanges property to meta reader

### DIFF
--- a/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.cxx
+++ b/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.cxx
@@ -303,7 +303,7 @@ void vtkSlicerMetafileImporterLogic::WriteSequenceMetafileImages(const std::stri
 
 //----------------------------------------------------------------------------
 vtkMRMLSequenceBrowserNode* vtkSlicerMetafileImporterLogic::ReadSequenceFile(const std::string& fileName, vtkCollection* addedSequenceNodes/*=NULL*/,
-const std::string& outputBrowserNodeID/*=std::string()*/)
+const std::string& outputBrowserNodeID/*=std::string()*/, bool saveSequenceChanges/*=true*/)
 {
   // Map the frame numbers to timestamps
   std::map< int, std::string > frameNumberToIndexValueMap;
@@ -475,7 +475,7 @@ const std::string& outputBrowserNodeID/*=std::string()*/)
         // Image
         // If save changes are allowed then proxy nodes are updated using shallow copy, which is much faster for images
         // (and images are usually not modified, so the risk of accidentally modifying data in the sequence is low).
-        sequenceBrowserNode->SetSaveChanges(*synchronizedNodesIt, true);
+        sequenceBrowserNode->SetSaveChanges(*synchronizedNodesIt, saveSequenceChanges);
         // Show image in slice viewers
         vtkMRMLVolumeNode* imageProxyVolumeNode = vtkMRMLVolumeNode::SafeDownCast(sequenceBrowserNode->GetProxyNode(*synchronizedNodesIt));
         if (imageProxyVolumeNode)

--- a/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.h
+++ b/MetafileImporter/Logic/vtkSlicerMetafileImporterLogic.h
@@ -81,7 +81,8 @@ public:
     \param addedNodes if not NULL then returns sequence nodes that are added to the scene.
     Returns the created browser node on success, NULL on failure.
   */
-  vtkMRMLSequenceBrowserNode* ReadSequenceFile(const std::string& fileName, vtkCollection* addedSequenceNodes=NULL, const std::string& outputBrowserID=std::string());
+  vtkMRMLSequenceBrowserNode* ReadSequenceFile(const std::string& fileName, vtkCollection* addedSequenceNodes=NULL, const std::string& outputBrowserID=std::string(),
+      bool saveSequenceChanges=true);
 
   /*! Write sequence metafile contents to the file */
   bool WriteSequenceMetafile(const std::string& fileName, vtkMRMLSequenceBrowserNode* browserNode);

--- a/MetafileImporter/Resources/UI/qSlicerMetafileIOOptionsWidget.ui
+++ b/MetafileImporter/Resources/UI/qSlicerMetafileIOOptionsWidget.ui
@@ -49,6 +49,16 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QCheckBox" name="SaveSequenceChangesCheckbox">
+     <property name="text">
+      <string>Save Sequence Changes</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/MetafileImporter/qSlicerMetafileIOOptionsWidget.cxx
+++ b/MetafileImporter/qSlicerMetafileIOOptionsWidget.cxx
@@ -50,6 +50,9 @@ qSlicerMetafileIOOptionsWidget::qSlicerMetafileIOOptionsWidget(QWidget* parentWi
 
   connect(d->OutputBrowserNodeIDEdit, SIGNAL(textChanged(QString)),
           this, SLOT(updateProperties()));
+  connect(d->SaveSequenceChangesCheckbox, SIGNAL(stateChanged(int)),
+          this, SLOT(updateProperties()));
+  updateProperties();  // ensure that the default gui values are set as properties
 }
 
 //-----------------------------------------------------------------------------
@@ -67,4 +70,5 @@ void qSlicerMetafileIOOptionsWidget::updateProperties()
     {
     d->Properties.remove("outputBrowserNodeID");
     }
+  d->Properties["saveSequenceChanges"] = d->SaveSequenceChangesCheckbox->isChecked();
 }

--- a/MetafileImporter/qSlicerMetafileReader.cxx
+++ b/MetafileImporter/qSlicerMetafileReader.cxx
@@ -121,7 +121,13 @@ bool qSlicerMetafileReader::load(const IOProperties& properties)
   {
       outputBrowserNodeID = properties["outputBrowserNodeID"].toString();
   }
-  vtkMRMLSequenceBrowserNode* browserNode = d->MetafileImporterLogic->ReadSequenceFile(fileName.toStdString(), loadedSequenceNodes.GetPointer(), outputBrowserNodeID.toStdString());
+  bool saveSequenceChanges = true;
+  if (properties.contains("saveSequenceChanges"))
+  {
+      saveSequenceChanges = properties["saveSequenceChanges"].toBool();
+  }
+  vtkMRMLSequenceBrowserNode* browserNode = d->MetafileImporterLogic->ReadSequenceFile(fileName.toStdString(), loadedSequenceNodes.GetPointer(), outputBrowserNodeID.toStdString(),
+      saveSequenceChanges);
   if (browserNode == NULL)
   {
     return false;


### PR DESCRIPTION
When adding multiple volume sequences to the same browser, if the timestamps of the sequences are not exactly the same, duplicate frames will be created at the master sequence node's timestamps because SetSaveChanges is set to true.

For example if load a .seq.mha with 3 frames. Then load another .seq.mha with 3 frames into the same browser. Checking the number of frames in the second sequence with `.GetNumberOfDataNodes()`, returns 4.

This PR adds the loading property saveSequenceChanges, which is true by default.
![image](https://user-images.githubusercontent.com/40271210/151586351-7c5a29be-2599-46cf-98f9-d8335a323fc7.png)
![image](https://user-images.githubusercontent.com/40271210/149798734-b5d56285-c077-4aae-8997-3646e60f5cb0.png)