### PR TITLE
COMP: Include the iostream header where cout/cerr used

### DIFF
--- a/SlicerIGSIOCommon/vtkSlicerIGSIOLogger.cxx
+++ b/SlicerIGSIOCommon/vtkSlicerIGSIOLogger.cxx
@@ -24,6 +24,10 @@ Care Ontario.
 #include <vtkIGSIOAccurateTimer.h>
 #include <vtkIGSIORecursiveCriticalSection.h>
 
+// STD includes
+#include <iostream>
+
+
 //-----------------------------------------------------------------------------
 namespace
 {


### PR DESCRIPTION
This change is necessary to be compatible with VTK 9.6 code as iostream was removed from a core header file as seen in https://github.com/Kitware/VTK/commit/a95326aef076dd9fc6d7329d5fb54f1015ca59b9. See release note https://github.com/Kitware/VTK/commit/7462a8b1411a78f470ca459a34cf1ef2e7c353a8.

SlicerIGSIO will build successfully against VTK 9.6 with this PR and https://github.com/IGSIO/IGSIO/pull/44.

This was originally caught by observing build errors for SlicerIGSIO extension.
https://slicer.cdash.org/builds/4143726/errors

cc: @Sunderlandkyl 