### PR TITLE
COMP: Harden vtkAddon version to use for custom builds

### DIFF
--- a/SuperBuild/External_IGSIO.cmake
+++ b/SuperBuild/External_IGSIO.cmake
@@ -31,15 +31,6 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
-  set(IGSIO_USE_3DSlicer ON)
-  if (DEFINED Slicer_EXTENSION_SOURCE_DIRS) # Custom build
-    set(IGSIO_USE_3DSlicer OFF)
-    list(APPEND ${proj}_DEPENDS
-      VTK
-      ITK
-      )
-  endif()
-
   set(BUILD_OPTIONS
     -DVTK_DIR:PATH=${VTK_DIR}
     -DITK_DIR:PATH=${ITK_DIR}
@@ -49,14 +40,33 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     -DZLIB_ROOT:PATH=${ZLIB_ROOT}
 
     -DIGSIO_SUPERBUILD:BOOL=ON
-    -DIGSIO_USE_3DSlicer:BOOL=${IGSIO_USE_3DSlicer}
     -DIGSIO_BUILD_VOLUMERECONSTRUCTION:BOOL=ON
     -DIGSIO_BUILD_SEQUENCEIO:BOOL=ON
     -DIGSIO_SEQUENCEIO_ENABLE_MKV:BOOL=ON
     -DIGSIO_USE_VP9:BOOL=${SlicerIGSIO_USE_VP9}
 
-    -DSlicer_DIR:PATH=${Slicer_DIR}
     -DBUILD_TESTING:BOOL=OFF
+    )
+
+  if(DEFINED Slicer_EXTENSION_SOURCE_DIRS) # Custom build
+    set(IGSIO_USE_3DSlicer OFF)
+    list(APPEND ${proj}_DEPENDS
+      VTK
+      ITK
+      )
+    ExternalProject_SetIfNotDefined(
+      vtkAddon_GIT_REVISION
+      "2ed3e2226cf25958b4dbf8bf917b2f7793ecd6a2" # harden vtkAddon to override IGSIO which specifies vtkAddon's main branch
+      QUIET
+      )
+    list(APPEND BUILD_OPTIONS
+      -DvtkAddon_GIT_REVISION:STRING=${vtkAddon_GIT_REVISION}
+    )
+  else()
+    set(IGSIO_USE_3DSlicer ON)
+  endif()
+  list(APPEND BUILD_OPTIONS
+    -DIGSIO_USE_3DSlicer:BOOL=${IGSIO_USE_3DSlicer}
     )
 
   if (IGSIO_USE_3DSlicer)


### PR DESCRIPTION
The IGSIO repo currently specifies the building of vtkAddon to use the "main" branch, so when SlicerIGSIO is built with IGSIO_USE_3DSlicer turned off, it began to fail due to recent updates to vtkAddon. When building SlicerIGSIO extension with an already built Slicer build with IGSIO_USE_3DSlicer set to ON, there wasn't an issue because 3D Slicer currently pins vtkAddon to a specific commit.

This commit pins vtkAddon to a specific hash for custom builds or will use the passed vtkAddon revision specified to the configuration of SlicerIGSIO.

cc: @Sunderlandkyl - it seems like you were having to do some recent compatibility fixes in IGSIO because of the recent vtkAddon integrated commits. I ran into issues with my 3D Slicer custom app which bundles SlicerIGSIO using a hardened commit and lists a hardened IGSIO commit to use, but IGSIO using its superbuild specified vtkAddon's `main` branch (note that other IGSIO dependencies such as libwebm [define a hardened hash](https://github.com/IGSIO/IGSIO/blob/c50cbca5ee98ed81288178dfe01a4ae8f4ec8ad3/SuperBuild/External_libwebm.cmake#L38) instead of using a branch name, so it could be considered to have IGSIO define a hardened vtkAddon version instead of SlicerIGSIO). In this case of building SlicerIGSIO into a custom app, `IGSIO_USE_3DSlicer` doesn't appear available to use as that seems to rely on a Slicer build tree as though building SlicerIGSIO as an extension against a Slicer build tree. Otherwise I would let the Slicer branch used by my custom app use its defined vtkAddon version and then have the building of IGSIO depend on that vtkAddon project and use that built version.

With the passing of `vtkAddon_GIT_REVISION` down into the IGSIO build, these changes will still need https://github.com/IGSIO/IGSIO/pull/46 to avoid it getting set back to `main`.

Ultimately with these changes I could specify `vtkAddon_GIT_REVISION` in my Slicer custom build CMakeLists.txt and `mark_as_superbuild(..)` to then be consumed by SlicerIGSIO to then pass to IGSIO and its superbuild of vtkAddon.