### PR TITLE
Support for CMake 4, Visual Studio 2026, Qt 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20.6...3.22.6 FATAL_ERROR)
 
 #-----------------------------------------------------------------------------
 set(EXTENSION_NAME SlicerIGSIO)

--- a/MetafileImporter/qSlicerMetafileImporterModule.h
+++ b/MetafileImporter/qSlicerMetafileImporterModule.h
@@ -23,8 +23,6 @@
 #include "qSlicerCoreApplication.h"
 #include "qSlicerModuleManager.h"
 
-#include "vtkSlicerConfigure.h" // For Slicer_HAVE_QT5
-
 #include "qSlicerMetafileImporterModuleExport.h"
 
 class qSlicerMetafileImporterModulePrivate;
@@ -36,9 +34,7 @@ qSlicerMetafileImporterModule
   : public qSlicerLoadableModule
 {
   Q_OBJECT
-#ifdef Slicer_HAVE_QT5
   Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
-#endif
   Q_INTERFACES(qSlicerLoadableModule);
 
 public:

--- a/SequenceIO/CMakeLists.txt
+++ b/SequenceIO/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.20.6...3.22.6 FATAL_ERROR)
 
 find_package(IGSIO REQUIRED)
 if (DEFINED Slicer_EXTENSION_SOURCE_DIRS) # Custom build

--- a/SequenceIO/qSlicerSequenceIOModule.h
+++ b/SequenceIO/qSlicerSequenceIOModule.h
@@ -35,9 +35,7 @@ class Q_SLICER_QTMODULES_SEQUENCEIO_EXPORT qSlicerSequenceIOModule :
 {
   Q_OBJECT;
   QVTK_OBJECT;
-#ifdef Slicer_HAVE_QT5
   Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
-#endif
   Q_INTERFACES(qSlicerLoadableModule);
 
 public:

--- a/SuperBuild/External_VP9.cmake
+++ b/SuperBuild/External_VP9.cmake
@@ -88,6 +88,8 @@ ExternalProject_Execute(${proj} \"build\" make)
     set(VP9_MSVC141_URL "${BASE_VP9_URL}msvc15.zip")
     set(VP9_MSVC142_URL "${BASE_VP9_URL}msvc16.zip")
     set(VP9_MSVC143_URL "${BASE_VP9_URL}msvc17.zip")
+    # No binaries available for VS2026 MSVC 145, but due to abi compatibility with MSVC 143, we can use the same binaries as for VS2022 MSVC 143.
+    set(VP9_MSVC145_URL "${BASE_VP9_URL}msvc17.zip")
 
     if(NOT DEFINED VP9_MSVC${MSVC_TOOLSET_VERSION}_URL)
       message(FATAL_ERROR "There are no binaries available for Microsoft C++ compiler ${MSVC_VERSION}")

--- a/SuperBuild/External_YASM.cmake
+++ b/SuperBuild/External_YASM.cmake
@@ -1,5 +1,13 @@
 set(proj YASM)
 
+# YASM is only required on Linux/macOS to compile VP9. On Windows, VP9 uses
+# pre-built binaries and does not need YASM.
+if(WIN32)
+  ExternalProject_Add_Empty(${proj} DEPENDS "")
+  mark_as_superbuild(${proj}_DIR:PATH)
+  return()
+endif()
+
 # Set dependency list
 set(${proj}_DEPENDS "")
 if(DEFINED Slicer_SOURCE_DIR)

--- a/VideoUtil/CMakeLists.txt
+++ b/VideoUtil/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.20.6...3.22.6 FATAL_ERROR)
 
 find_package(IGSIO REQUIRED)
 if (DEFINED Slicer_EXTENSION_SOURCE_DIRS) # Custom build

--- a/VideoUtil/qSlicerVideoUtilModule.h
+++ b/VideoUtil/qSlicerVideoUtilModule.h
@@ -35,9 +35,7 @@ class Q_SLICER_QTMODULES_VIDEOUTIL_EXPORT qSlicerVideoUtilModule :
 {
   Q_OBJECT;
   QVTK_OBJECT;
-#ifdef Slicer_HAVE_QT5
   Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
-#endif
   Q_INTERFACES(qSlicerLoadableModule);
 
 public:


### PR DESCRIPTION
This is a collection of commits as I have been working on getting the build working with latest build tools including Visual Studio 2026 and CMake 4.

@Sunderlandkyl I added `COMP: Do not add YASM in build process for Windows` to help me work around the YASM project on the Windows platform as https://github.com/yasm/yasm does not have CMake 4 support (see https://github.com/yasm/yasm/blob/a2f8bdf075bcad90a1b0a446080906ef6afe6847/CMakeLists.txt#L2) and passing `-DCMAKE_POLICY_VERSION_MINIMUM:STRING=3.5` appears to result in the YASM build failing because it can't seem to handle some of the newer policies. The related VP9 project has also gone archived (https://github.com/ShiftMediaProject/libvpx) with no Windows binaries built with Visual Studio 2026. So not sure what you want to do about VP9/YASM for the long term. 